### PR TITLE
Fix coverage report

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,1 @@
+SimpleCov.start 'rails'

--- a/.simplecov
+++ b/.simplecov
@@ -1,1 +1,6 @@
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' do
+  add_filter 'lib/tasks/cucumber.rake'
+  add_filter 'app/mailer'
+  add_filter 'app/channels'
+  add_filter 'app/job'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :development, :test do
   gem 'poltergeist'
   gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'timecop'
-
+  gem 'simplecov', github: 'colszowka/simplecov'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ group :development, :test do
   gem 'poltergeist'
   gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'timecop'
-  gem 'simplecov', github: 'colszowka/simplecov'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,15 @@ GIT
       activerecord (= 5.0.0)
       ice_cube_chosko (~> 0.2.0)
 
+GIT
+  remote: git://github.com/colszowka/simplecov.git
+  revision: 257e26394c464c4ab388631b4eff1aa98c37d3f1
+  specs:
+    simplecov (0.12.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -287,10 +296,6 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    simplecov (0.12.0)
-      docile (~> 1.1.0)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
     spring (1.7.2)
@@ -372,6 +377,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   shoulda-matchers
+  simplecov!
   spring
   spring-watcher-listen (~> 2.0.0)
   timecop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,15 +7,6 @@ GIT
       activerecord (= 5.0.0)
       ice_cube_chosko (~> 0.2.0)
 
-GIT
-  remote: git://github.com/colszowka/simplecov.git
-  revision: 257e26394c464c4ab388631b4eff1aa98c37d3f1
-  specs:
-    simplecov (0.12.0)
-      docile (~> 1.1.0)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -296,6 +287,10 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    simplecov (0.12.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
     spring (1.7.2)
@@ -377,7 +372,6 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   shoulda-matchers
-  simplecov!
   spring
   spring-watcher-listen (~> 2.0.0)
   timecop

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -9,7 +9,8 @@ ActionController::Base.allow_rescue = false
 begin
   DatabaseCleaner.strategy = :transaction
 rescue NameError
-  raise 'You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it.'
+  raise 'You need to add database_cleaner to your Gemfile ' \
+        '(in the :test group) if you wish to use it.'
 end
 
 Cucumber::Rails::Database.javascript_strategy = :truncation

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,5 +1,6 @@
 require 'coveralls'
 Coveralls.wear_merged!('rails')
+
 require 'cucumber/rails'
 require 'capybara-screenshot/cucumber'
 require_relative 'temporal'

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -7,6 +7,6 @@ unless Rails.env.production?
 
   namespace :ci do
     desc 'Run all tests and generate a merged coverage report'
-    task tests: [:spec, :cucumber_rerun, 'coveralls:push']
+    task tests: [:spec, :cucumber, 'coveralls:push']
   end
 end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,0 +1,12 @@
+unless Rails.env.production?
+  require 'rspec/core/rake_task'
+  require 'cucumber/rake/task'
+  require 'coveralls/rake/task'
+
+  Coveralls::RakeTask.new
+
+  namespace :ci do
+    desc 'Run all tests and generate a merged coverage report'
+    task tests: [:spec, :cucumber_rerun, 'coveralls:push']
+  end
+end

--- a/lib/tasks/coveralls.rake
+++ b/lib/tasks/coveralls.rake
@@ -4,7 +4,5 @@ if Rails.env.development? || Rails.env.test?
   require 'coveralls/rake/task'
 
   Coveralls::RakeTask.new
-  task test_with_coveralls: [:spec,
-                             :cucumber_rerun,
-                             'coveralls:push']
+  task test_with_coveralls: [:spec, :cucumber, 'coveralls:push']
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,14 @@
 require 'coveralls'
 Coveralls.wear_merged!('rails')
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
+
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
-
 end


### PR DESCRIPTION
Title of the PT story: Fix merge of coverage report

Link to PT story: https://www.pivotaltracker.com/story/show/128477717

Description of the PR:

1. Revert to `:cucumber` instead of `:cucumber_rerun` that was the cause of lower test coverage
2. Add `.simplecov` file with filters to exclude unnecessary folders/file from coverage
3. Introduce new/clean rake task (`ci:tests`) to replace `test_with_coveralls` 

Ready for review!
@tochman 