### PR TITLE
Modal fix

### DIFF
--- a/app/views/dashboard/_dashboard.js.erb
+++ b/app/views/dashboard/_dashboard.js.erb
@@ -115,9 +115,10 @@ function getDispalyedDate() {
 }
 
 function populateAndShowModal(object) {
-  var modal, errorModal, newDate;
+  var modal, errorModal, date, newDate;
   modal = new Foundation.Reveal($('#slot-modal'));
   errorModal = new Foundation.Reveal($('#error-modal'));
+  date = getDispalyedDate();
   newDate = new Date(date + " 00:00");
   if (newDate < today()) {
     errorModal.open();

--- a/app/views/dashboard/_modal.html.haml
+++ b/app/views/dashboard/_modal.html.haml
@@ -30,5 +30,7 @@
     %span{aria: {hidden: ''}}
       &times;
   #model-content
-    %h3 Unavailable
-    %p.lead This date has already passed.
+    %h3
+      = t('dashboard.unavailable')
+    %p
+      = t('dashboard.error')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,8 @@ en:
     button: Create
     capacity: 'Capacity:'
     details: 'Details:'
+    unavailable: Unavailable
+    error: This date has already passed.
   footer:
     home: Home
     instructions: Instructions

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -22,6 +22,8 @@ sv:
     button: Skapa
     capacity: 'Kapacitet:'
     details: 'Detaljer:'
+    unavailable: Inte tillgänglig
+    error: Detta datum har redan passerat.
   footer:
     home: Hem
     instructions: Instruktioner


### PR DESCRIPTION
Title of the PT story: Error modal is no longer working

Link to PT story: https://www.pivotaltracker.com/story/show/130894861


Description of the PR:

1. Error modal is now properly displayed when clicking a passed date
2. Added translation to the error message so it now can be displayed as English and Swedish


Ready for review!
@tochman @diraulo