### PR TITLE
Overlapping slots fix

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -16,6 +16,7 @@ class DashboardController < ApplicationController
 
     end_seconds = Time.parse([booking_params[:booking_date],
                               booking_params[:time_end]].join(' ')).seconds_since_midnight
+    start_seconds += 1.second
 
     start = Date.parse(booking_params[:booking_date]) + start_seconds.seconds
     to = Date.parse(booking_params[:booking_date]) + end_seconds.seconds


### PR DESCRIPTION
Title of the PT story: Booking doesn't overlap correctly

Link to PT story: https://www.pivotaltracker.com/story/show/130900429


Description of the PR:

1. Updated dashboard controller so that you now can overlap bookings



Ready for review!
@tochman @diraulo
