### PR TITLE
Users can only see resources from their own facility

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
 
   # Temporal authorization method
   def authenticate_superuser
-    redirect_to root_path, alert: 'You are not authorized to view this page' unless current_user.superadmin
+    redirect_to root_path, alert: 'You are not authorized to view this page' unless current_user.superadmin?
   end
 
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,7 +2,11 @@ class DashboardController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @resources = Resource.all
+    if current_user.superadmin?
+      @resources = Resource.all
+    else
+      @resources = current_user.try(:facility).try(:resources) || Resource.all
+    end
   end
 
   def create_booking

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -1,3 +1,5 @@
 class Facility < ApplicationRecord
   has_many :users
+  has_many :resources
+
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -6,6 +6,9 @@ class Resource < ApplicationRecord
   validates_presence_of :designation, :uuid
   validates_uniqueness_of :uuid
 
+  belongs_to :facility
+
+
   def current_day_bookings(date)
     self.bookings.select {|booking| booking.time_start.to_date == Date.parse(date)}
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   belongs_to :facility
-  #after_create :set_admin
 
   def active_for_authentication?
     super && approved?
@@ -19,5 +18,5 @@ class User < ApplicationRecord
       super # Use whatever other message
     end
   end
-  
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,8 @@ class User < ApplicationRecord
     end
   end
 
+  def user?
+    !self.superadmin
+  end
+
 end

--- a/config/locales/devise.sv.yml
+++ b/config/locales/devise.sv.yml
@@ -50,8 +50,8 @@ sv:
       new:
         reset_password: Återställ lösenord
     sessions:
-      signed_in: 'Logga in.'
-      signed_out: 'Logga ut.'
+      signed_in: 'Du är nu inloggad i systemet'
+      signed_out: 'Du är nu utloggad ur systemet'
       new:
         sign_in: 'Logga in'
     shared:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,5 +3,5 @@ copyright_message: Copyright Craft Academy Labs © 2016
 available_locales: ['sv', 'en']
 default_locale: en
 # Available modes: 'daily_view' & 'weekly_view'
-# mode: :daily_view
-mode: :weekly_view
+mode: :daily_view
+#mode: :weekly_view

--- a/db/migrate/20161109184153_add_facility_to_resources.rb
+++ b/db/migrate/20161109184153_add_facility_to_resources.rb
@@ -1,0 +1,5 @@
+class AddFacilityToResources < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :resources, :facility, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161104140105) do
+ActiveRecord::Schema.define(version: 20161109184153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,8 @@ ActiveRecord::Schema.define(version: 20161104140105) do
     t.integer  "capacity"
     t.text     "schedule"
     t.string   "uuid"
+    t.integer  "facility_id"
+    t.index ["facility_id"], name: "index_resources_on_facility_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|
@@ -69,5 +71,6 @@ ActiveRecord::Schema.define(version: 20161104140105) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "resources", "facilities"
   add_foreign_key "users", "facilities"
 end

--- a/features/admin_landing_page.feature
+++ b/features/admin_landing_page.feature
@@ -3,17 +3,24 @@ Feature: As an Administrator
   In order to get an overview of current resource bookings
   I would like to see a dashboard with today's bookings on the landing page
 
-
   Background:
-    Given the following account is configured
-      | email            | password       |
-      | admin@random.com | admin_password |
+    Given the following facilities exists
+      | name          |
+      | Stena Center  |
+      | Craft Academy |
 
-    Given the following resources exist
-      | designation | description         |
-      | Galaxy      | The Galaxy room     |
-      | Atlantis    | The Atlantis room   |
-      | Enterprise  | The Enterprise room |
+    And the following accounts are configured
+      | email                   | password       | facility      |
+      | admin@stena-center.com  | admin_password | Stena Center  |
+      | admin@craft-academy.com | admin_password | Craft Academy |
+
+    And the following resources exist
+      | designation    | description             | facility      |
+      | Galaxy         | The Galaxy room         | Stena Center  |
+      | Atlantis       | The Atlantis room       | Stena Center  |
+      | Enterprise     | The Enterprise room     | Stena Center  |
+      | Cohort Room    | The Cohort Room         | Craft Academy |
+      | NCC Enterprise | The NCC Enterprise room | Craft Academy |
 
 
   Scenario: Visit landing page without logging in
@@ -22,7 +29,7 @@ Feature: As an Administrator
     And I should see "You need to sign in or sign up before continuing."
 
   Scenario: Visit landing page as admin
-    Given I am logged in as "admin@random.com"
+    Given I am logged in as "admin@stena-center.com"
     And I navigate to the "landing" page
     Then I should see "Click on the rooms you want to book or make a change."
     And I should see "GALAXY"

--- a/features/admin_landing_page.feature
+++ b/features/admin_landing_page.feature
@@ -34,9 +34,12 @@ Feature: As an Administrator
     Then I should see "Click on the rooms you want to book or make a change."
     And I should see "GALAXY"
     And I should see "ATLANTIS"
+    And I should see "ENTERPRISE"
+    And I should not see "NCC ENTERPRISE"
+    And I should not see "COHORT ROOM"
 
   Scenario: Toggle details visibility
-    Given I am using the dashboard on "2016-01-01"
+    Given I am using the dashboard on "2016-01-01" as "admin@stena-center.com"
     And I click on "Galaxy"
     Then I should see "The Galaxy room"
     And I should not see "The Atlantis room"

--- a/features/admin_landing_page.feature
+++ b/features/admin_landing_page.feature
@@ -3,6 +3,12 @@ Feature: As an Administrator
   In order to get an overview of current resource bookings
   I would like to see a dashboard with today's bookings on the landing page
 
+  Additional User Story:
+  As a system user
+  In order to take bookings on my resources
+  I only want to see my own resources on the dashboard
+
+
   Background:
     Given the following facilities exists
       | name          |

--- a/features/admin_landing_page_weekly_navigation.feature
+++ b/features/admin_landing_page_weekly_navigation.feature
@@ -4,11 +4,17 @@ Feature: As a system administrator
   I would like to be able to choose between daily and weekly navigation
 
   Background:
-    Given the following account is configured
-      | email            | password       |
-      | admin@random.com | admin_password |
+    Given the following facilities exists
+      | name          |
+      | Stena Center  |
+      | Craft Academy |
 
-    And I am logged in as "admin@random.com"
+    And the following accounts are configured
+      | email                   | password       | facility      |
+      | admin@stena-center.com  | admin_password | Stena Center  |
+      | admin@craft-academy.com | admin_password | Craft Academy |
+
+    And I am logged in as "admin@craft-academy.com "
 
   Scenario: Weekly view
     Given the application is set up for "weekly view"

--- a/features/booking.feature
+++ b/features/booking.feature
@@ -1,3 +1,4 @@
+@javascript
 Feature: As an admin
   In order be able to book a resource
   I would like to see current bookings on the dashboard
@@ -6,15 +7,19 @@ Feature: As an admin
   Background:
     Given time is frozen at 2016-01-01
 
-    And the following account is configured
-      | email            | password       |
-      | admin@random.com | admin_password |
+    Given the following facilities exists
+      | name         |
+      | Stena Center |
+
+    And the following accounts are configured
+      | email                  | password       | facility     |
+      | admin@stena-center.com | admin_password | Stena Center |
 
     And the following resources exist
-      | designation | description         |
-      | Galaxy      | The Galaxy room     |
-      | Atlantis    | The Atlantis room   |
-      | Enterprise  | The Enterprise room |
+      | designation | description         | facility     |
+      | Galaxy      | The Galaxy room     | Stena Center |
+      | Atlantis    | The Atlantis room   | Stena Center |
+      | Enterprise  | The Enterprise room | Stena Center |
 
     And the following bookings exist
       | resource | client | date       | start_time | end_time |
@@ -24,19 +29,17 @@ Feature: As an admin
       | Atlantis | Volvo  | 2016-01-02 | 08:00      | 09:30    |
       | Atlantis | Thomas | 2016-01-02 | 17:00      | 18:30    |
 
-  @javascript
   Scenario: Displaying bookings
     Given time is frozen at 2016-01-02
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     Then there should be "2" current bookings for "Galaxy"
     And I should see bookings for "Galaxy"
     Then there should be "3" current bookings for "Atlantis"
     And I should see bookings for "Atlantis"
 
-  @javascript
   Scenario: Displaying booking details
     Given time is frozen at 2016-01-02
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     Then I should see the following content in resource box
       | content                                     | resource |
       | Group: Thomas Starts: 10:30 Finishes: 11:30 | Galaxy   |
@@ -45,18 +48,15 @@ Feature: As an admin
       | Group: Volvo Starts: 08:00 Finishes: 09:30  | Atlantis |
       | Group: Thomas Starts: 17:00 Finishes: 18:30 | Atlantis |
 
-  @javascript
   Scenario: Display slot details
     Given time is frozen at 2016-01-02
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     And I click on "11:00 - 11:30" for "Atlantis"
     Then I should see a details modal for "11:00 - 11:30" for "Atlantis"
 
-
-  @javascript
   Scenario: Create a booking on slot
     Given time is frozen at 2016-01-02
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     And I click arrow "next"
     And I scroll down in the "Galaxy" box
     And I click on "16:30 - 17:00" for "Galaxy"
@@ -66,14 +66,12 @@ Feature: As an admin
     And I click "Create"
     And I scroll down in the "Galaxy" box
     Then I should see the following content in resource box
-      | content                                               | resource |
+      | content                                                 | resource |
       | Group: Craft Academy Labs Starts: 16:00 Finishes: 16:30 | Galaxy   |
     And I should see "2016-01-03"
 
-  @javascript
   Scenario: Change a booking
-
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     And I scroll down in the "Galaxy" box
     And I click on "10:30 - 11:00" for "Galaxy"
     And I fill in "Client" with "Thomas Ochman"
@@ -82,47 +80,40 @@ Feature: As an admin
     And I click "Update"
     And I scroll down in the "Galaxy" box
     Then I should see the following content in resource box
-      | content                                          | resource |
+      | content                                            | resource |
       | Group: Thomas Ochman Starts: 12:00 Finishes: 13:30 | Galaxy   |
 
 
-  @javascript
   Scenario: Rejects a booking on unavailable slot
-    Given I want to make a booking with following settings
-      | resource | date       | slot          | start | end   | client  |
-      | Galaxy   | 2016-01-02 | 10:30 - 11:00 | 10:30 | 11:00 | Jessica |
+    And I want to make a booking with following settings
+      | resource | date       | slot          | start | end   | client  | user                   |
+      | Galaxy   | 2016-01-02 | 10:30 - 11:00 | 10:30 | 11:00 | Jessica | admin@stena-center.com |
     Then I should get "The room is already booked" message
 
-  @javascript
   Scenario: Rejects a booking on past date
     Given time is frozen at 2016-01-02
-    Given I want to make a booking with following settings
-      | resource | date       | slot          | start | end   | client  |
-      | Galaxy   | 2016-01-01 | 10:30 - 11:00 | 10:30 | 11:00 | Jessica |
+    And I want to make a booking with following settings
+      | resource | date       | slot          | start | end   | client  |user                   |
+      | Galaxy   | 2016-01-01 | 10:30 - 11:00 | 10:30 | 11:00 | Jessica |admin@stena-center.com |
     Then I should get "Validation failed: time start can't be in the past" message
 
-
-  @javascript
   Scenario: Rejects a booking without a client
     Given I want to make a booking with following settings
-      | resource | date       | slot          | start | end   | client |
-      | Galaxy   | 2016-01-01 | 19:30 - 20:00 | 19:30 | 20:00 |        |
+      | resource | date       | slot          | start | end   | client |user                   |
+      | Galaxy   | 2016-01-01 | 19:30 - 20:00 | 19:30 | 20:00 |        |admin@stena-center.com |
     Then I should get "Validation failed: client can't be empty" message
 
-
-  @javascript
   Scenario: Edit a reservation
     Given time is frozen at 2016-01-02
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     And I click on "17:00 - 17:30" for "Atlantis"
     Then I should see a details modal for "17:00 - 17:30" for "Atlantis"
     And I should see "Thomas"
     And I should see "Edit reservation"
 
-  @javascript
   Scenario: Delete a reservation
     Given time is frozen at 2016-01-02
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     And I click on "17:00 - 17:30" for "Atlantis"
     And I should see "Edit reservation"
     Then I click on "Delete"

--- a/features/navigate_dates.feature
+++ b/features/navigate_dates.feature
@@ -7,15 +7,20 @@ Feature: As a dashboard user
   Background:
     Given time is frozen at 2016-01-01
 
-    And the following account is configured
-      | email            | password       |
-      | admin@random.com | admin_password |
+    Given the following facilities exists
+      | name          |
+      | Stena Center  |
+      | Craft Academy |
+
+    And the following accounts are configured
+      | email                   | password       | facility      |
+      | admin@stena-center.com  | admin_password | Stena Center  |
 
     And the following resources exist
-      | designation | description         |
-      | Galaxy      | The Galaxy room     |
-      | Atlantis    | The Atlantis room   |
-      | Enterprise  | The Enterprise room |
+      | designation    | description             | facility      |
+      | Galaxy         | The Galaxy room         | Stena Center  |
+      | Atlantis       | The Atlantis room       | Stena Center  |
+      | Enterprise     | The Enterprise room     | Stena Center  |
 
     And the following bookings exist
       | resource | client | date       | start_time | end_time |
@@ -33,13 +38,13 @@ Feature: As a dashboard user
 
   Scenario: Navigating to next date
     Given time is frozen at 2016-01-02
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     And I click arrow "next"
     Then I should see "2016-01-03"
 
 
   Scenario: Navigating to previous date
     Given time is frozen at 2016-01-02
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     And I click arrow "previous"
     Then I should see "2016-01-01"

--- a/features/navigate_weeks.feature
+++ b/features/navigate_weeks.feature
@@ -8,25 +8,31 @@ Feature: As a dashboard user
     Given time is frozen at 2016-01-01
     And the application is set up for "weekly view"
 
-    And the following account is configured
-      | email            | password       |
-      | admin@random.com | admin_password |
+    Given the following facilities exists
+      | name          |
+      | Stena Center  |
+      | Craft Academy |
+
+    And the following accounts are configured
+      | email                   | password       | facility      |
+      | admin@stena-center.com  | admin_password | Stena Center  |
 
     And the following resources exist
-      | designation | description         |
-      | Galaxy      | The Galaxy room     |
-      | Atlantis    | The Atlantis room   |
-      | Enterprise  | The Enterprise room |
+      | designation    | description             | facility      |
+      | Galaxy         | The Galaxy room         | Stena Center  |
+      | Atlantis       | The Atlantis room       | Stena Center  |
+      | Enterprise     | The Enterprise room     | Stena Center  |
+
 
   Scenario: Navigating to next week
     Given time is frozen at 2016-01-02
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     And I click arrow "next"
     Then I should see "Week of 2016-01-04 - 2016-01-10"
 
 
   Scenario: Navigating to previous week
     Given time is frozen at 2016-01-02
-    And I am using the dashboard on "2016-01-02"
+    And I am using the dashboard on "2016-01-02" as "admin@stena-center.com"
     And I click arrow "previous"
     Then I should see "Week of 2015-12-21 - 2015-12-27"

--- a/features/navigate_weeks.feature
+++ b/features/navigate_weeks.feature
@@ -18,20 +18,6 @@ Feature: As a dashboard user
       | Atlantis    | The Atlantis room   |
       | Enterprise  | The Enterprise room |
 
-#    And the following bookings exist
-#      | resource | client | date       |
-#      | Galaxy   | Thomas | 2016-01-02 |
-#      | Galaxy   | Raoul  | 2016-01-02 |
-#      | Atlantis | Raoul  | 2016-01-02 |
-#      | Atlantis | Volvo  | 2016-01-02 |
-#      | Atlantis | Thomas | 2016-01-02 |
-#      | Galaxy   | Thomas | 2016-01-03 |
-#      | Galaxy   | Raoul  | 2016-01-03 |
-#      | Atlantis | Raoul  | 2016-01-03 |
-#      | Atlantis | Volvo  | 2016-01-03 |
-#      | Atlantis | Thomas | 2016-01-03 |
-
-
   Scenario: Navigating to next week
     Given time is frozen at 2016-01-02
     And I am using the dashboard on "2016-01-02"

--- a/features/step_definitions/booking_steps.rb
+++ b/features/step_definitions/booking_steps.rb
@@ -74,7 +74,7 @@ Given(/^I want to make a booking with following settings$/) do |table|
              time_start: settings[:start],
              time_end: settings[:end]}
 
-  @session.post(user_session_path, params: {user: {email: 'admin@random.com', password: 'admin_password', remember_me: '0'}})
+  @session.post(user_session_path, params: {user: {email: settings[:user], password: 'admin_password', remember_me: '0'}})
   @session.post(create_booking_path(locale: :en), params: {booking: booking})
   @session.follow_redirect!
 

--- a/features/step_definitions/facilities_steps.rb
+++ b/features/step_definitions/facilities_steps.rb
@@ -2,6 +2,12 @@ Given(/^a facility named "([^"]*)" exists$/) do |name|
   FactoryGirl.create(:facility, name: name)
 end
 
+And(/^the following facilities exists$/) do |table|
+  table.hashes.each do |facility|
+    FactoryGirl.create(:facility, name: facility[:name])
+  end
+end
+
 And(/^I select "([^"]*)" from "([^"]*)"$/) do |value, field|
   select value, from: field
 end
@@ -19,3 +25,4 @@ And(/^I assign "([^"]*)" to "([^"]*)"$/) do |user, facility_name|
     click_button 'Add'
   end
 end
+

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -1,6 +1,11 @@
 Given(/^the following (?:account|accounts) (?:is|are) configured$/) do |table|
-  table.hashes.each do |user|
-    FactoryGirl.create(:user, user.merge!(approved: true))
+  table.hashes.each do |hash|
+    facility = Facility.find_by(name: hash[:facility])
+    FactoryGirl.create(:user,
+                       email: hash[:email],
+                       password: hash[:password] || 'password',
+                       approved: true,
+                       facility: facility || nil)
   end
 end
 
@@ -9,8 +14,8 @@ Given(/^I am logged out$/) do
 end
 
 Given(/^I am logged in as "([^"]*)"$/) do |value|
-  user = User.find_by(email: value, approved: true)
-  if user.nil?
+  user = User.find_by(email: value.strip, approved: true)
+  unless user
     user = FactoryGirl.create(:user, email: value, superadmin: false)
   end
   login_as(user, scope: :user)
@@ -39,8 +44,12 @@ Given(/^I attempt to login$/) do
 end
 
 Given(/^the following resources exist$/) do |table|
-  table.hashes.each do |resource|
-    FactoryGirl.create(:resource, resource)
+  table.hashes.each do |hash|
+    facility = Facility.find_by(name: hash[:facility])
+    FactoryGirl.create(:resource,
+                       designation: hash[:designation],
+                       description: hash[:description],
+                       facility: facility)
   end
 end
 

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -123,9 +123,9 @@ Then(/^show me an image of the page$/) do
   Capybara::Screenshot.screenshot_and_open_image
 end
 
-Given(/^I am using the dashboard on "([^"]*)"$/) do |time|
-  steps %q{
-    Given I am logged in as "admin@random.com"
+Given(/^I am using the dashboard on "([^"]*)" as "([^"]*)"$/) do |time, email|
+  steps %Q{
+    Given I am logged in as "#{email}"
     And I navigate to the "landing" page
   }
 

--- a/spec/helpers/facilities_helper_spec.rb
+++ b/spec/helpers/facilities_helper_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe FacilitiesHelper, type: :helper do
     end
 
     it 'returns select options of users without a facility' do
-      expected_collection = [['user_2@facility.com', user_2.id], ['user_3@facility.com', user_3.id]]
-      expect(helper.unassigned_users_select_options).to match expected_collection
+      expected_collection = [['user_2@facility.com', user_2.id], ['user_3@facility.com', user_3.id]].sort
+      expect(helper.unassigned_users_select_options.sort).to match expected_collection
     end
   end
 

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -15,5 +15,6 @@ RSpec.describe Facility, type: :model do
 
   describe 'Associations' do
     it { is_expected.to have_many :users }
+    it { is_expected.to have_many :resources }
   end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Resource, type: :model do
     it {is_expected.to validate_uniqueness_of :uuid}
   end
 
+  describe 'Associations' do
+    it { is_expected.to belong_to :facility }
+  end
+
   describe 'bookable methods' do
     subject { FactoryGirl.create(:resource) }
     let(:user) { FactoryGirl.create(:user) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,6 +23,28 @@ RSpec.describe User, type: :model do
     it { is_expected.to respond_to :approved }
   end
 
+  describe 'Roles' do
+    let(:user_1) { create(:user, superadmin: true) }
+    let(:user_2) { create(:user, superadmin: false) }
+
+    it 'user? should respond true if not superadmin' do
+      expect(user_2.user?).to be_truthy
+    end
+
+    it 'user? should respond false if superadmin' do
+      expect(user_1.user?).to be_falsey
+    end
+
+    it 'superadmin? should respond true if superadmin' do
+      expect(user_1.superadmin?).to be_truthy
+    end
+
+    it 'superadmin? should respond true if user' do
+      expect(user_2.superadmin?).to be_falsey
+    end
+
+  end
+
   describe 'bookable methods' do
     subject { FactoryGirl.create(:user) }
     let(:resource) { FactoryGirl.create(:resource) }


### PR DESCRIPTION
Title of the PT story: Users can only see resources from their own facility

Link to PT story: https://www.pivotaltracker.com/story/show/133836465


Description of the PR:

1. adds relation Facility -> Resource
2. modifies the display of resources to only show those associated with the currently logged in user
3. shows all resources for `superadmin`

No need to add CanCanCan since we are restricting the views in the controller and there are no Crud actions for Resources. 

This is ready for review @diraulo and @AmberWilkie 

