### PR TITLE
specify test suites commands for simplecov

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+SimpleCov.command_name 'Cucumber Features'
 
 require 'cucumber/rails'
 require 'capybara-screenshot/cucumber'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+SimpleCov.command_name 'RSpec'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Title of the PT story: no story

Description of the PR:

1. Specify test suites commands for `simplecov`. This should allow it to group coverage results appropriately now and hopefully partly fix the coverage issue we've been experiencing...

Ready for review!
@tochman

