### PR TITLE
Add identification code to Facility

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -20,7 +20,8 @@ class Api::ApiController < ActionController::API
   end
 
   def create
-    @resource = Resource.new(resource_params)
+    facility = Facility.find_by(code: params[:resource][:f_code])
+    @resource = Resource.new(resource_params.merge(facility: facility))
     @resource.schedule = IceCube::Schedule.new(Date.today - 1.year, duration: 1.year)
     @resource.schedule.add_recurrence_rule IceCube::Rule.daily
     if @resource.save

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -15,5 +15,4 @@ class Facility < ApplicationRecord
     end
   end
 
-
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -11,7 +11,7 @@ class Facility < ApplicationRecord
 
   def generate_random_code
     if self.code.nil?
-      self.code = [*('a'..'z'),*('0'..'9')].shuffle[0,4].join
+      self.code = [*('a'..'z'),*('0'..'9')].sample(4).join
     end
   end
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -1,5 +1,19 @@
 class Facility < ApplicationRecord
+
+  validates_presence_of :name, :code
+  validates_length_of :code, is: 4
+  before_validation :generate_random_code
+
   has_many :users
   has_many :resources
+
+  private
+
+  def generate_random_code
+    if self.code.nil?
+      self.code = [*('a'..'z'),*('0'..'9')].shuffle[0,4].join
+    end
+  end
+
 
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -3,7 +3,7 @@ class Resource < ApplicationRecord
                    capacity_type: :closed,
                    bookable_across_occurrences: true
 
-  validates_presence_of :designation, :uuid
+  validates_presence_of :designation, :uuid, :facility
   validates_uniqueness_of :uuid
 
   belongs_to :facility

--- a/db/migrate/20161110170439_add_code_to_facilities.rb
+++ b/db/migrate/20161110170439_add_code_to_facilities.rb
@@ -1,0 +1,5 @@
+class AddCodeToFacilities < ActiveRecord::Migration[5.0]
+  def change
+    add_column :facilities, :code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161109184153) do
+ActiveRecord::Schema.define(version: 20161110170439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20161109184153) do
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "code"
   end
 
   create_table "resources", force: :cascade do |t|

--- a/features/translations.feature
+++ b/features/translations.feature
@@ -6,13 +6,17 @@ Feature: As a system user
   Background:
     Given time is frozen at 2016-01-02
     And the application is set up for "daily view"
-    And the following account is configured
-      | email           | password |
-      | admin@email.com | password |
+    Given the following facilities exists
+      | name         |
+      | Stena Center |
+
+    And the following accounts are configured
+      | email           | password       | facility     |
+      | admin@email.com | admin_password | Stena Center |
 
     And the following resources exist
-      | designation | description     |
-      | Galaxy      | The Galaxy room |
+      | designation | description     | facility     |
+      | Galaxy      | The Galaxy room | Stena Center |
 
     And the following bookings exist
       | resource | client | date       | start_time | end_time |

--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :facility do
     name 'MyString'
+    code '12ab'
   end
 end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     description 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.
         Fuga, officiis sunt neque facilis culpa molestiae necessitatibus delectus veniam provident.'
     uuid { SecureRandom.uuid }
+    association :facility
     capacity 4
     schedule {
       schedule = IceCube::Schedule.new(Date.today - 1.year, duration: 1.year)

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -11,10 +11,17 @@ RSpec.describe Facility, type: :model do
   describe 'DB table' do
     it { is_expected.to have_db_column :id }
     it { is_expected.to have_db_column :name }
+    it { is_expected.to have_db_column :code }
   end
 
   describe 'Associations' do
     it { is_expected.to have_many :users }
     it { is_expected.to have_many :resources }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_length_of(:code).is_equal_to(4) }
+
   end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Resource, type: :model do
     it {is_expected.to validate_presence_of :designation}
     it {is_expected.to validate_presence_of :capacity}
     it {is_expected.to validate_presence_of :schedule}
+    it {is_expected.to validate_presence_of :facility}
 
     it {is_expected.to validate_uniqueness_of :uuid}
   end

--- a/spec/requests/api/resource_endpoints_spec.rb
+++ b/spec/requests/api/resource_endpoints_spec.rb
@@ -4,8 +4,10 @@ require 'rails_helper'
 
 describe Api::ApiController, type: :request do
   describe 'create resource endpoint' do
+    let!(:facility) { create(:facility, code: 'qwer')}
     it 'creates an object with valid request' do
       post api_resources_path, {params: {resource: {uuid: '123e4567-e89b-12d3-a456-426655440000',
+                                                    f_code: facility.code,
                                                     designation: 'New conference room',
                                                     capacity: 20}}, headers: {'HTTP_ACCEPT': 'application/json'}}
 

--- a/spec/requests/api/resource_endpoints_spec.rb
+++ b/spec/requests/api/resource_endpoints_spec.rb
@@ -19,15 +19,26 @@ describe Api::ApiController, type: :request do
       expect(response_json).to eq expected_response.as_json
     end
 
+    it 'reject object creation without facility' do
+      post api_resources_path, {params: {resource: {uuid: '123e4567-e89b-12d3-a456-426655440000',
+                                                    f_code: '',
+                                                    designation: 'New conference room',
+                                                    capacity: 20}}, headers: {'HTTP_ACCEPT': 'application/json'}}
+
+      expected_error_response = ['Facility can\'t be blank'].sort
+      expect(response_json['message']).to eq expected_error_response
+    end
+
     it 'reject object creation on invalid request' do
       post api_resources_path, {params: {resource: {uuid: '123e4567-e89b-12d3-a456-426655440000'}}, headers: {'HTTP_ACCEPT': 'application/json'}}
-      expected_error_response = ['Capacity is not a number', 'Capacity can\'t be blank', 'Designation can\'t be blank'].sort
+      expected_error_response = ['Capacity is not a number', 'Capacity can\'t be blank', 'Designation can\'t be blank', 'Facility can\'t be blank'].sort
       expect(response_json['message']).to eq expected_error_response
     end
 
 
     it 'reject object creation without uuid' do
       post api_resources_path, {params: {resource: {uuid: '',
+                                                    f_code: facility.code,
                                                     designation: 'New conference room',
                                                     capacity: 20}}, headers: {'HTTP_ACCEPT': 'application/json'}}
 


### PR DESCRIPTION
### Add identification code to Facility

As a mobile app administrator
In order to assign a new resource to the correct facility
I would like to use a 4 digit code to identify the facility to witch the resource belongs

Link to PT story: https://www.pivotaltracker.com/story/show/133802209

Description of the PR:

1. adds `generate_random_code` to Facility (4 digit code needed to create a Resource)
2. adds relationship Facility `has_many` Resource with validation of `:facility` 
3. modifies the `create` method in ApiController

ready for review @diraulo and @AmberWilkie 