### PR TITLE
load js files in appropriate places

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,7 +18,4 @@
 //= require mockdate
 //= require date
 //= require date/sv-SE
-//= require_tree .
-
-
-
+//= require header_footer

--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,3 +1,7 @@
+//= require cable
+//= require date_extensions
+
+
 function queryApi(date) {
   $.ajax({
     dataType: "json",
@@ -88,4 +92,3 @@ function cableSubscribe() {
 }
 
 $(document).ready(cableSubscribe);
-


### PR DESCRIPTION
Title of the PT story: **dashboard.js should only be loaded on the dashboard.**

Link to PT story: https://www.pivotaltracker.com/story/show/137691985

Description of the PR:

1. remove `require_tree` in `application.js`. We should only load js files needed by the entire application
2. Load dashboard specific javascript in `dashboard.js`

Ready for code review!
@tochman @AmberWilkie 
