### PR TITLE
Temporarily remove validation to address

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -3,7 +3,7 @@ class Resource < ApplicationRecord
                    capacity_type: :closed,
                    bookable_across_occurrences: true
 
-  validates_presence_of :designation, :uuid, :facility, :direction
+  validates_presence_of :designation, :uuid, :facility #, :direction
   validates_uniqueness_of :uuid
 
   belongs_to :facility

--- a/features/send_notification.feature
+++ b/features/send_notification.feature
@@ -26,7 +26,6 @@ Feature: As an administrator of a facility
     Given I am logged in as "admin@stena-center.com"
     And I navigate to the "landing" page
     When I fill in "note" with "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturien. Extra text that won't get sent"
-    And show me an image of the page
     And I click "Send"
     Then I should see "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturien."
     Then I should not see "Extra text that won't get sent"

--- a/features/superadmin_facilities_page.feature
+++ b/features/superadmin_facilities_page.feature
@@ -29,7 +29,6 @@ Feature: As a Superadmin
   Scenario: Viewing aggregated info on Facilities index page
     When I click on "Admin"
     And I click on "Facilities"
-#    Then show me an image of the page
     Then I should see "Galaxy" in a section for "Stena Center"
     And I should see "Atlantis" in a section for "Stena Center"
     And I should see "Enterprise" in a section for "Stena Center"

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Resource, type: :model do
     it {is_expected.to validate_presence_of :capacity}
     it {is_expected.to validate_presence_of :schedule}
     it {is_expected.to validate_presence_of :facility}
-    it {is_expected.to validate_presence_of :direction}
+    # it {is_expected.to validate_presence_of :direction}
 
     it {is_expected.to validate_uniqueness_of :uuid}
   end

--- a/spec/requests/api/resource_endpoints_spec.rb
+++ b/spec/requests/api/resource_endpoints_spec.rb
@@ -63,8 +63,8 @@ describe Api::ApiController, type: :request do
         "Capacity is not a number",
         "Capacity can't be blank",
         "Designation can't be blank",
-        "Facility can't be blank",
-        "Direction can't be blank"
+        "Facility can't be blank"
+        # "Direction can't be blank"
       ].sort
 
       expect(response_json['message']).to eq expected_error_response


### PR DESCRIPTION
No PT Story

Remove validation on the `direction` field for now, to allow the creation of resources - until we add it to the client's setup form.

Ready for code review!
@AmberWilkie 
