### PR TITLE
Flash disappears

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,3 +19,4 @@
 //= require date
 //= require date/sv-SE
 //= require header_footer
+//= require flash_messages

--- a/app/assets/javascripts/flash_messages.js
+++ b/app/assets/javascripts/flash_messages.js
@@ -1,5 +1,4 @@
-// set flash messages timeout to 5 seconds
+// set flash messages timeout to 15 seconds
 setTimeout(function(){
     $('#flash-message').hide()
-
 }, 15000);

--- a/app/assets/javascripts/flash_messages.js
+++ b/app/assets/javascripts/flash_messages.js
@@ -1,0 +1,5 @@
+// set flash messages timeout to 5 seconds
+setTimeout(function(){
+    $('#flash-message').hide()
+
+}, 15000);

--- a/app/views/layouts/_flash_messages.html.haml
+++ b/app/views/layouts/_flash_messages.html.haml
@@ -1,3 +1,6 @@
 - flash.each do |key, value|
-  %div{class: "callout #{callout(key)}"}
+  %div{class: "callout #{callout(key)}", data: { closable: true }}
     = value
+    %button{class: 'close-button', data: { close: true }, type: 'button'}
+      %span{ 'aria-hidden' => true }
+        &times;

--- a/app/views/layouts/_flash_messages.html.haml
+++ b/app/views/layouts/_flash_messages.html.haml
@@ -1,5 +1,5 @@
 - flash.each do |key, value|
-  %div{class: "callout #{callout(key)}", data: { closable: true }}
+  %div{class: "callout #{callout(key)}", id: 'flash-message', data: { closable: true }}
     = value
     %button{class: 'close-button', data: { close: true }, type: 'button'}
       %span{ 'aria-hidden' => true }

--- a/features/site_layout.feature
+++ b/features/site_layout.feature
@@ -1,0 +1,9 @@
+Feature: Check various site layout components
+
+  @javascript
+  Scenario: Flash message disspears after 15 seconds
+    Given I navigate to the "landing" page
+    Then I should be on the "login" page
+    And I should see "You need to sign in or sign up before continuing."
+    Then I wait for 16 seconds
+    Then I should not see "You need to sign in or sign up before continuing."

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -182,6 +182,10 @@ When(/^I switch to window "([^"]*)"$/) do |index|
   switch_to_window(windows[index.to_i - 1])
 end
 
+Then(/^I wait for (\d+) seconds$/) do |seconds|
+  sleep seconds.to_i.seconds
+end
+
 private
 
 def mock_date_script(time)


### PR DESCRIPTION
Title of the PT story: Make flash messages disappear after 10 - 15 seconds

Link to PT story: https://www.pivotaltracker.com/story/show/131060533


Description of the PR:

1. Make the flash messages disappear after 15 seconds
2. Flash messages are now closable



Ready for review!
@tochman @diraulo
